### PR TITLE
Remove the universal wheel tag

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,8 +30,5 @@ install_requires =
     pyserial
 python_requires = >=3.8
 
-[bdist_wheel]
-universal=1
-
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
We no longer support python <3.8