### PR TITLE
Adds VMIN property, confirms VMIN values for PPS16005 and DPPS3220.

### DIFF
--- a/voltcraft/pps.py
+++ b/voltcraft/pps.py
@@ -94,9 +94,7 @@ class PPS:
         try:
             self._vmin = PPS_MIN_VOLTAGE[self._model]
         except KeyError:
-            raise RuntimeError(
-                f"unknown minimum voltage for Voltcraft {self._model}"
-            )
+            raise RuntimeError(f"unknown minimum voltage for Voltcraft {self._model}")
 
         if bool(reset):
             self.output(0)
@@ -158,7 +156,9 @@ class PPS:
 
     def voltage(self, voltage: float) -> None:
         """set voltage: silently saturates at VMIN and VMAX"""
-        voltage = min(max(int(self._vmin * 10), int(voltage * 10)), int(self._vmax * 10))
+        voltage = min(
+            max(int(self._vmin * 10), int(voltage * 10)), int(self._vmax * 10)
+        )
         self._query("VOLT%03d" % voltage)
 
     def current(self, current: float) -> None:

--- a/voltcraft/pps.py
+++ b/voltcraft/pps.py
@@ -158,7 +158,7 @@ class PPS:
 
     def voltage(self, voltage: float) -> None:
         """set voltage: silently saturates at VMIN and VMAX"""
-        voltage = min(max(self._vmin * 10, int(voltage * 10)), int(self._vmax * 10))
+        voltage = min(max(int(self._vmin * 10), int(voltage * 10)), int(self._vmax * 10))
         self._query("VOLT%03d" % voltage)
 
     def current(self, current: float) -> None:

--- a/voltcraft/pps.py
+++ b/voltcraft/pps.py
@@ -23,6 +23,19 @@ PPS_MODELS = {
     (60.5, 11.0): "DPPS6010",
 }
 
+# Some models have a minimum voltage.
+PPS_MIN_VOLTAGE = {
+    "PPS11810": 0,      # not confirmed yet
+    "PPS11360": 0,      # not confirmed yet
+    "PPS11603": 0,      # not confirmed yet
+    "PPS13610": 0,      # not confirmed yet
+    "PPS16005": 0.8,    # confirmed by jonathanlarochelle 2023-10-27
+    "PPS11815": 0,      # not confirmed yet
+    "DPPS3220": 0.8,    # confirmed by jonathanlarochelle 2023-10-27
+    "DPPS3230": 0,      # not confirmed yet
+    "DPPS6010": 0       # not confirmed yet
+}
+
 PPS_TIMEOUT = 1.00
 
 
@@ -78,6 +91,12 @@ class PPS:
                 )
             )
 
+        try:
+            self._vmin = PPS_MIN_VOLTAGE[self._model]
+        except KeyError:
+            raise RuntimeError("unknown minimum voltage for Voltcraft {}"
+                               .format(self._model))
+
         if bool(reset):
             self.output(0)
             self.voltage(0)
@@ -95,6 +114,11 @@ class PPS:
     def IMAX(self) -> float:
         """maximum output current"""
         return self._imax
+
+    @property
+    def VMIN(self) -> float:
+        """minimum output voltage"""
+        return self._vmin
 
     @property
     def MODEL(self) -> str:
@@ -132,8 +156,8 @@ class PPS:
         self._query("SOUT%d" % state)
 
     def voltage(self, voltage: float) -> None:
-        """set voltage: silently saturates at 0 and VMAX"""
-        voltage = min(max(0, int(voltage * 10)), int(self._vmax * 10))
+        """set voltage: silently saturates at VMIN and VMAX"""
+        voltage = min(max(self._vmin * 10, int(voltage * 10)), int(self._vmax * 10))
         self._query("VOLT%03d" % voltage)
 
     def current(self, current: float) -> None:
@@ -162,7 +186,7 @@ class PPS:
         for voltage, current in [VC0, VC1, VC2]:
             vcs.append(
                 (
-                    min(max(0.0, voltage), self._vmax) * 10,
+                    min(max(self._vmin, voltage), self._vmax) * 10,
                     min(max(0.0, current), self._imax) * self._imult,
                 )
             )
@@ -206,7 +230,7 @@ class PPS:
 
     @preset_voltage.setter
     def preset_voltage(self, voltage: float) -> None:
-        voltage = min(max(0.0, float(voltage)), self._vmax) * 10
+        voltage = min(max(self._vmin, float(voltage)), self._vmax) * 10
         self._query("SOVP%03d" % int(voltage))
 
     @property

--- a/voltcraft/pps.py
+++ b/voltcraft/pps.py
@@ -25,15 +25,15 @@ PPS_MODELS = {
 
 # Some models have a minimum voltage.
 PPS_MIN_VOLTAGE = {
-    "PPS11810": 0,      # not confirmed yet
-    "PPS11360": 0,      # not confirmed yet
-    "PPS11603": 0,      # not confirmed yet
-    "PPS13610": 0,      # not confirmed yet
-    "PPS16005": 0.8,    # confirmed by jonathanlarochelle 2023-10-27
-    "PPS11815": 0,      # not confirmed yet
-    "DPPS3220": 0.8,    # confirmed by jonathanlarochelle 2023-10-27
-    "DPPS3230": 0,      # not confirmed yet
-    "DPPS6010": 0       # not confirmed yet
+    "PPS11810": 0,  # not confirmed yet
+    "PPS11360": 0,  # not confirmed yet
+    "PPS11603": 0,  # not confirmed yet
+    "PPS13610": 0,  # not confirmed yet
+    "PPS16005": 0.8,  # confirmed by jonathanlarochelle 2023-10-27
+    "PPS11815": 0,  # not confirmed yet
+    "DPPS3220": 0.8,  # confirmed by jonathanlarochelle 2023-10-27
+    "DPPS3230": 0,  # not confirmed yet
+    "DPPS6010": 0,  # not confirmed yet
 }
 
 PPS_TIMEOUT = 1.00
@@ -94,8 +94,9 @@ class PPS:
         try:
             self._vmin = PPS_MIN_VOLTAGE[self._model]
         except KeyError:
-            raise RuntimeError("unknown minimum voltage for Voltcraft {}"
-                               .format(self._model))
+            raise RuntimeError(
+                f"unknown minimum voltage for Voltcraft {self._model}"
+            )
 
         if bool(reset):
             self.output(0)


### PR DESCRIPTION
Addresses issue #20 by 

- adding PPS_MIN_VOLTAGE, which defines the minimum voltage for every supported voltcraft device. Note that I could only confirm the minimum values for PPS16005 and DPPS3220. I have set the other values to zero.
- adding VMIN property, which is read from PPS_MIN_VOLTAGE with the model string.
- Voltage setting silently saturates at VMIN and VMAX
