### PR TITLE
Added minimum voltage of the PPS-11360

### DIFF
--- a/voltcraft/pps.py
+++ b/voltcraft/pps.py
@@ -26,7 +26,7 @@ PPS_MODELS = {
 # Some models have a minimum voltage.
 PPS_MIN_VOLTAGE = {
     "PPS11810": 0,  # not confirmed yet
-    "PPS11360": 0,  # not confirmed yet
+    "PPS11360": 0.8,  # confirmed by michael-dauer 2023-11-08
     "PPS11603": 0,  # not confirmed yet
     "PPS13610": 0,  # not confirmed yet
     "PPS16005": 0.8,  # confirmed by jonathanlarochelle 2023-10-27


### PR DESCRIPTION
Fix a SerialTimeoutException raised during reset of the device as reported by @jonathanlarochelle for the model PPS-16005 and by myself for the model PPS-11360. The PPS in question have a minimum voltage below which the configuration with the `VOLT` command fails and the serial communication times out as the command is not acknowleded by an `OK` response.