### PR TITLE
Add DPPS1640 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and [www.conrad.com (DPPS)](https://www.conrad.com/search?search=voltcraft%20dpp
 ```python
 from voltcraft.pps import PPS
 
-supply = PPS(port="/dev/ttyUSB0", reset=True)
+supply = PPS(port="/dev/ttyUSB0", reset=True) #in Windows change the port string to COMx (in my case COM4)
 
 supply.voltage(10.0)
 supply.current(2.0)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and [www.conrad.com (DPPS)](https://www.conrad.com/search?search=voltcraft%20dpp
 ```python
 from voltcraft.pps import PPS
 
-supply = PPS(port="/dev/ttyUSB0", reset=True) #in Windows change the port string to COMx (in my case COM4)
+supply = PPS(port="/dev/ttyUSB0", reset=True)  # in Windows change string to COMx (eg COM4)
 
 supply.voltage(10.0)
 supply.current(2.0)

--- a/voltcraft/pps.py
+++ b/voltcraft/pps.py
@@ -36,7 +36,7 @@ PPS_MIN_VOLTAGE = {
     "DPPS3220": 0.8,  # confirmed by jonathanlarochelle 2023-10-27
     "DPPS3230": 0,  # not confirmed yet
     "DPPS6010": 0,  # not confirmed yet
-    "DPPS1640": 1.0, # confirmed by chillinglu 2024-03-13
+    "DPPS1640": 1.0,  # confirmed by chillinglu 2024-03-13
 }
 
 PPS_TIMEOUT = 1.00
@@ -53,7 +53,7 @@ def _pps_debug(s: str, debug: bool = True) -> None:
 class PPS:
     def __init__(
         self,
-        port: str = "/dev/ttyUSB0", #in Windows change this string to COMx (in my case COM4)
+        port: str = "/dev/ttyUSB0",  # in Windows change this string to COMx (in my case COM4)
         reset: bool = True,
         prom: int | None = None,
         debug: bool = False,

--- a/voltcraft/pps.py
+++ b/voltcraft/pps.py
@@ -53,7 +53,7 @@ def _pps_debug(s: str, debug: bool = True) -> None:
 class PPS:
     def __init__(
         self,
-        port: str = "/dev/ttyUSB0",  # in Windows change this string to COMx (in my case COM4)
+        port: str = "/dev/ttyUSB0",  # in Windows change string to COMx (eg COM4)
         reset: bool = True,
         prom: int | None = None,
         debug: bool = False,

--- a/voltcraft/pps.py
+++ b/voltcraft/pps.py
@@ -22,6 +22,7 @@ PPS_MODELS = {
     (32.2, 21.5): "DPPS3220",  # added tykling 2019-03-26
     (32.2, 31.5): "DPPS3230",  # added cdleonard 2023-09-13
     (60.5, 11.0): "DPPS6010",
+    (16.2, 43.0): "DPPS1640",  # added chillinglu 2024-03-13
 }
 
 # Some models have a minimum voltage.
@@ -35,6 +36,7 @@ PPS_MIN_VOLTAGE = {
     "DPPS3220": 0.8,  # confirmed by jonathanlarochelle 2023-10-27
     "DPPS3230": 0,  # not confirmed yet
     "DPPS6010": 0,  # not confirmed yet
+    "DPPS1640": 1.0, # confirmed by chillinglu 2024-03-13
 }
 
 PPS_TIMEOUT = 1.00
@@ -51,7 +53,7 @@ def _pps_debug(s: str, debug: bool = True) -> None:
 class PPS:
     def __init__(
         self,
-        port: str = "/dev/ttyUSB0",
+        port: str = "/dev/ttyUSB0", #in Windows change this string to COMx (in my case COM4)
         reset: bool = True,
         prom: int | None = None,
         debug: bool = False,


### PR DESCRIPTION
added the 16V 40A DPPS1640 power supply, where the naming actually makes sense and also commented about the port string change for windows users.

Thanks for sharing the module!!