### PR TITLE
allow unknown models with fallback to 0.0 min current

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,20 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
+  rev: v6.0.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer
   - id: check-added-large-files
 - repo: https://github.com/pycqa/isort
-  rev: 6.0.1
+  rev: 7.0.0
   hooks:
   - id: isort
 - repo: https://github.com/psf/black
-  rev: 25.1.0
+  rev: 25.12.0
   hooks:
   - id: black
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: 'v1.17.1'
+  rev: 'v1.19.1'
   hooks:
   - id: mypy
 - repo: https://github.com/PyCQA/flake8
@@ -22,10 +22,10 @@ repos:
   hooks:
   - id: flake8
     additional_dependencies:
-    - flake8-black==0.3.6
+    - flake8-black==0.4.0
     exclude: "^(build|docs|setup.py)|tests[/]"
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.20.0
+    rev: v3.21.2
     hooks:
     - id: pyupgrade
       args: [--py38-plus]

--- a/voltcraft/pps.py
+++ b/voltcraft/pps.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import functools
 import sys
+import warnings
 from typing import Literal
 
 import serial
@@ -91,18 +92,24 @@ class PPS:
         try:
             self._model = PPS_MODELS[(self._vmax, self._imax)]
         except KeyError:
-            self._serial.close()
-            raise RuntimeError(
-                "unknown Voltcraft PPS model with max V: {}, I: {}".format(
-                    self._vmax, self._imax
+            # Grace mode: unknown model, continue with measured limits
+            self._model = "UNKNOWN"
+            warnings.warn(
+                (
+                    "Unknown Voltcraft PPS model (VMAX=%.1f, IMAX=%.1f).\n"
+                    "Please open a PR at https://github.com/ap--/voltcraft"
+                    'to add to PPS_MODELS: (%.1f, %.1f): "MODEL_NAME"'
                 )
+                % (self._vmax, self._imax, self._vmax, self._imax),
+                RuntimeWarning,
+                stacklevel=2,
             )
 
         try:
             self._vmin = PPS_MIN_VOLTAGE[self._model]
         except KeyError:
-            self._serial.close()
-            raise RuntimeError(f"unknown minimum voltage for Voltcraft {self._model}")
+            # Grace mode: unknown minimum voltage, default to 0.0
+            self._vmin = 0.0
 
         if bool(reset):
             self.output(0)


### PR DESCRIPTION
* instead of RunTime error set model to `UNKNOWN` a min current to 0.0

* also update pre-commit packages due to problem with:
```
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

voltcraft/pps.py:0:1: BLK900 Failed to load file: decode_bytes() missing required argument 'mode' (pos 2)
```
closes #62